### PR TITLE
🚧 Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
       day: friday
       time: '20:00'
       timezone: Europe/London
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: monthly
       day: friday
       time: '20:00'
       timezone: Europe/London

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: friday
+      time: '20:00'
+      timezone: Europe/London
+    open-pull-requests-limit: 20
+    reviewers:
+      - stringbean
+    assignees:
+      - stringbean
+    groups:
+      runtime-dependencies:
+        update-types:
+          - minor
+          - patch
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: friday
+      time: '20:00'
+      timezone: Europe/London
+    reviewers:
+      - stringbean
+    assignees:
+      - stringbean
+    groups:
+      GH-Actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.release.tag_name}}
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ jobs:
   test:
     steps:
       - name: Get container status
-        uses: stringbean/docker-healthcheck-action@v1
+        uses: stringbean/docker-healthcheck-action@v3
         id: missing-container
         with:
           container: unknown
@@ -34,7 +34,7 @@ jobs:
       - name: Start container
         run: docker run -d --rm --name hello-world crccheck/hello-world
       - name: Wait for container
-        uses: stringbean/docker-healthcheck-action@v1
+        uses: stringbean/docker-healthcheck-action@v3
         with:
           container: hello-world
           wait-time: 50

--- a/package-lock.json
+++ b/package-lock.json
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.1",
         "dockerode": "^4.0.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Michael Stringer",
   "license": "Apache-2.0",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.1",
     "dockerode": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi there thanks for the nice GHA 😄 

The readme threw me a bit off and I used `v1` instead of realizing that `v3` is the latest version 🤦‍♀️
With `v1` I got the following warning
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
Hence the dependency updates.

Hope those changes are still welcome, even so they were made under a wrong assumption.
I also updated the usage examples to use `v3` instead of `v1`, so other noobs like me don't fall in the same pit 😅
